### PR TITLE
Allow user to select day on calendar by clicking on it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.vscode/

--- a/assets/css/calendar.css
+++ b/assets/css/calendar.css
@@ -23,6 +23,10 @@
     background-color: #00f;
 }
 
+.calendar-row td.current-day {
+    background-color: #52be72;
+}
+
 .inactive-month {
     color: #f00;
 }


### PR DESCRIPTION
Additionally, automatically select either:
- the current day on initial calendar render or when rendering the current month of the current year (such as when paging back to this month)
- the first of the currently displayed month on switching months